### PR TITLE
Include the build hash in the cache key for daily builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,3 +25,21 @@ jobs:
                 version: ${{ matrix.version }}
             - name: Run tests in Blender
               run: blender --version
+
+            # `blender --version` passes even when a months-old build was restored
+            # from the cache, so check the build we got is the one we resolved
+            - name: Check the installed daily is the resolved daily
+              if: matrix.version == 'daily' && env.CACHE_VERSION != ''
+              shell: bash
+              run: |
+                installed=$(blender --version | sed -n 's/.*build hash:[[:space:]]*\([0-9a-f]\{6,\}\).*/\1/p' | head -n 1)
+                echo "resolved: ${CACHE_VERSION}"
+                echo "installed: ${installed}"
+                if [ -z "${installed}" ]; then
+                  echo "::error::could not read a build hash from 'blender --version'"
+                  exit 1
+                fi
+                if [ "${CACHE_VERSION}" != "${FULL_VERSION}-${installed}" ]; then
+                  echo "::error::installed daily ${installed} is not the resolved build ${CACHE_VERSION} - a stale cache was restored"
+                  exit 1
+                fi

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The action also sets helpful environment variables:
 - `BLENDER_BASE_VERSION`: Base series (e.g. `4.2`).
 - `FULL_VERSION`: Full version resolved (e.g. `4.2.6`).
 - `IS_DAILY`: `true` if using a daily build, otherwise `false`.
+- `CACHE_VERSION`: The version component of the cache key (see [Caching](#caching)).
 - Daily builds only: `BLEND_URL_WINDOWS_X64`, `BLEND_URL_WINDOWS_ARM64`, `BLEND_URL_MACOS_X64`, `BLEND_URL_MACOS_ARM64`, `BLEND_URL_LINUX_X64`.
 
 Example workflow installing Blender for multiple versions across OSes, then printing the version:
@@ -56,11 +57,13 @@ jobs:
 This action automatically caches downloaded Blender archives to speed up subsequent runs. The cache key is based on:
 - Operating system (`runner.os`)
 - Architecture (`runner.arch`)
-- Full Blender version (`FULL_VERSION`)
+- `CACHE_VERSION`, which is the full Blender version for releases (e.g. `4.2.6`), and the version plus the build hash for daily builds (e.g. `5.3.0-16f3180fba1e`)
+
+The build hash matters because every daily in a series reports the same version. Keying on the version alone would match the first daily ever cached and keep restoring it, so `version: daily` would silently test a build that is weeks or months old. Including the hash means a new daily is a new key, and each platform is keyed on the hash of the build it actually downloads — the builder does not always publish every platform from the same commit.
 
 When the same version is requested on the same platform, the cached download will be restored instead of downloading again. This significantly reduces action runtime and bandwidth usage.
 
-The cache is managed automatically by the action - no configuration is required.
+The cache is managed automatically by the action - no configuration is required. If the build hash for a daily cannot be determined, caching is skipped for that run so a fresh build is always downloaded.
 
 Notes:
 - `daily` builds come from the daily builder and are not official releases. Use for testing against upcoming changes.

--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,12 @@ runs:
 
     - name: Restore Blender from cache
       id: cache-blender
+      if: env.CACHE_VERSION != ''
       uses: actions/cache/restore@v4
       with:
         path: |
           blender-download.*
-        key: blender-${{ runner.os }}-${{ runner.arch }}-${{ env.FULL_VERSION }}
+        key: blender-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_VERSION }}
 
     - name: Install Blender Linux
       if: runner.os == 'Linux'
@@ -81,9 +82,9 @@ runs:
         echo "$env:GITHUB_WORKSPACE/../blender" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Save Blender to cache
-      if: steps.cache-blender.outputs.cache-hit != 'true'
+      if: env.CACHE_VERSION != '' && steps.cache-blender.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: |
           blender-download.*
-        key: blender-${{ runner.os }}-${{ runner.arch }}-${{ env.FULL_VERSION }}
+        key: blender-${{ runner.os }}-${{ runner.arch }}-${{ env.CACHE_VERSION }}

--- a/scripts/set_versions.py
+++ b/scripts/set_versions.py
@@ -6,11 +6,15 @@
 # ]
 # ///
 import os
+import platform
 import re
 import sys
 import requests
 from bs4 import BeautifulSoup
 from typing import Tuple, List
+
+# the commit hash in a daily filename, e.g. blender-5.3.0-alpha+main.16f3180fba1e-linux...
+BUILD_HASH_PATTERN = re.compile(r"\+\w+\.([0-9a-f]+)-")
 
 
 def fetch_url(url: str) -> BeautifulSoup:
@@ -107,17 +111,53 @@ def get_latest_builds(target_version: str = None) -> dict:
             platform_links["linux"]["x64"].append(href)
 
     env_vars = {}
-    for platform, archs in platform_links.items():
+    for os_name, archs in platform_links.items():
         for arch, links in archs.items():
             if links:
                 latest = max(
                     links,
                     key=lambda x: re.search(r"blender-(\d+\.\d+\.\d+)", x).group(1),
                 )
-                env_name = f"BLEND_URL_{platform.upper()}_{arch.upper()}"
+                env_name = f"BLEND_URL_{os_name.upper()}_{arch.upper()}"
                 env_vars[env_name] = latest
 
     return env_vars
+
+
+def get_build_url_var() -> str:
+    """The BLEND_URL_* variable holding the build for the runner we're executing on."""
+    arch = "ARM64" if platform.machine().lower() in ("arm64", "aarch64") else "X64"
+    system = platform.system()
+    if system == "Windows":
+        return f"BLEND_URL_WINDOWS_{arch}"
+    if system == "Darwin":
+        return f"BLEND_URL_MACOS_{arch}"
+    return "BLEND_URL_LINUX_X64"
+
+
+def get_cache_version(full_version: str, build_urls: dict) -> str:
+    """
+    The version component of the cache key for a daily build.
+
+    Every daily of a series reports the same FULL_VERSION, so keying the cache on
+    that alone pins the first daily ever cached and never downloads another one.
+    The commit hash from the filename is what actually changes between builds.
+
+    Returns an empty string if the hash can't be read, which disables caching so a
+    change to Blender's filenames costs us a download rather than silently serving
+    a stale build forever.
+    """
+    url = build_urls.get(get_build_url_var())
+    if url is None:
+        print(f"No daily build URL for {get_build_url_var()}, caching disabled")
+        return ""
+
+    match = BUILD_HASH_PATTERN.search(url)
+    if match is None:
+        print(f"Could not read a build hash from {url}, caching disabled")
+        return ""
+
+    return f"{full_version}-{match.group(1)}"
 
 
 def get_daily_versions() -> List[str]:
@@ -213,7 +253,12 @@ def set_versions(version: str) -> Tuple[str, str, bool]:
     )
 
     if is_daily:
-        env_vars.update(get_latest_builds(target_version))
+        build_urls = get_latest_builds(target_version)
+        env_vars.update(build_urls)
+        env_vars["CACHE_VERSION"] = get_cache_version(full_version, build_urls)
+    else:
+        # a release version identifies its download exactly
+        env_vars["CACHE_VERSION"] = full_version
 
     write_github_env(env_vars)
     return base_version, full_version, is_daily


### PR DESCRIPTION
## The problem

`version: daily` has not been installing the latest daily build. It installs whichever daily was cached first.

`set_versions.py` resolves `FULL_VERSION` to the version number alone — `5.3.0` — for every daily in the series. The cache key is `blender-${{ runner.os }}-${{ runner.arch }}-${{ env.FULL_VERSION }}`, so once `blender-Linux-X64-5.3.0` is saved it is a cache hit on every subsequent run forever, and the install step's `if [ ! -f "blender-download.tar.xz" ]` guard skips the download.

This is not theoretical. In `MolecularNodes` CI it had been pinned since June: the resolution step correctly discovered the current daily (`BLEND_URL_LINUX_X64=...main.d0c98651e6fb-...`), but the Blender that launched reported `hash e5fc656cdab0 built 2026-06-04`. Two months of "daily" runs were testing one stale alpha, which segfaulted on Linux and Windows and made it look like a regression in the project under test.

## The fix

Emit a new `CACHE_VERSION` and key the cache on that:

- releases → the full version (e.g. `4.2.23`), which identifies the download exactly, so behaviour is unchanged
- dailies → version plus commit hash (e.g. `5.3.0-16f3180fba1e`)

The hash is read from the `BLEND_URL_*` for the platform the runner is actually on, rather than any one build's hash. That matters — as of this writing the builder has Linux and Windows on `16f3180fba1e` but macOS on `91996a59888c`, so a single shared hash would key at least one platform against a build it never downloads.

If the hash can't be read (no build published for the platform, or an upstream filename change), `CACHE_VERSION` is empty and both cache steps are skipped via `if: env.CACHE_VERSION != ''`. That degrades to always downloading, rather than silently serving stale builds again.

Also renames the `platform` loop variable in `get_latest_builds` to `os_name`, since it shadowed the newly imported `platform` module.

## Verification

Ran `set_versions.py` against the live builder for `daily`, `latest`, and `4.2`, and exercised the platform mapping and both fallback paths:

```
Linux   x86_64    -> BLEND_URL_LINUX_X64        CACHE_VERSION='5.3.0-16f3180fba1e'
Linux   aarch64   -> BLEND_URL_LINUX_X64        CACHE_VERSION='5.3.0-16f3180fba1e'
Darwin  arm64     -> BLEND_URL_MACOS_ARM64      CACHE_VERSION='5.3.0-91996a59888c'
Windows AMD64     -> BLEND_URL_WINDOWS_X64      CACHE_VERSION='5.3.0-16f3180fba1e'
Windows ARM64     -> BLEND_URL_WINDOWS_ARM64    CACHE_VERSION='5.3.0-16f3180fba1e'
macOS x64, no such build -> ''
unparseable filename     -> ''
```

`latest` → `5.2.0`, `4.2` → `4.2.23`. `ruff check` is at the same 7 pre-existing findings as `main`; `ruff format --check` is clean.

## Note on rollout

Existing `blender-*-5.3.0` caches simply stop being matched, since the new key has a different shape — no manual cache deletion needed. Consumers pinned to `@v5` will need the tag moved (or a new tag) to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)