### PR TITLE
Update pinned actions to node24 runtime

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
               version: ["daily", "latest", "4.2", "4.3", "4.4", "4.3.2", "4.1", "4.0.2"]
               os: [macos-latest, "ubuntu-latest", "windows-latest"]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7.0.1
             - name: Install Blender
               uses: ./
               with:

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: "latest"
     - name: Set version variables
@@ -21,7 +21,7 @@ runs:
     - name: Restore Blender from cache
       id: cache-blender
       if: env.CACHE_VERSION != ''
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6.1.0
       with:
         path: |
           blender-download.*
@@ -83,7 +83,7 @@ runs:
 
     - name: Save Blender to cache
       if: env.CACHE_VERSION != '' && steps.cache-blender.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6.1.0
       with:
         path: |
           blender-download.*

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.1
+      uses: astral-sh/setup-uv@v10
       with:
         version: "latest"
     - name: Set version variables
@@ -21,7 +21,7 @@ runs:
     - name: Restore Blender from cache
       id: cache-blender
       if: env.CACHE_VERSION != ''
-      uses: actions/cache/restore@v6.1.0
+      uses: actions/cache/restore@v6
       with:
         path: |
           blender-download.*
@@ -83,7 +83,7 @@ runs:
 
     - name: Save Blender to cache
       if: env.CACHE_VERSION != '' && steps.cache-blender.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v6.1.0
+      uses: actions/cache/save@v6
       with:
         path: |
           blender-download.*


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4 to v7.0.1
- Bump `astral-sh/setup-uv` from v5 to v10.0.1
- Bump `actions/cache/restore` and `actions/cache/save` from v4 to v6.1.0

All of these now run on the node24 runtime, which removes the "Node 20 is being deprecated" warnings that showed up in workflow runs. Checked each project's changelog between the old and new majors — no breaking changes affect how this action uses them (only `version`, `path`, and `key` inputs are used; no self-hosted runners; workflow doesn't use `pull_request_target`/`workflow_run` events).

## Test plan
- [ ] CI run on this PR passes across the existing OS/version matrix
- [ ] No Node 20 deprecation warnings appear in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hw3hLzwm8GxiQDb71zGHz